### PR TITLE
Fix keepalived template configuration

### DIFF
--- a/utils/install.go
+++ b/utils/install.go
@@ -74,7 +74,7 @@ func writeKeepAlivedServiceFiles(config VIPConfiguration) {
 	kaConfFileTemplate :=
 		`vrrp_instance K8S_APISERVER {
 	interface {{.NetworkInterface}}
-	state MASTER
+	state BACKUP
 	virtual_router_id {{.RouterID}}
 	nopreempt
 	authentication {


### PR DESCRIPTION
We need keepalived to come up in BACKUP state. This will trigger a
leader election. Using MASTER state for keepalived instances may cause
duplicate VIP instantiations.