### PR TITLE
Fix 'Failed Unit' error after nodeadm reset

### DIFF
--- a/cmd/nodereset.go
+++ b/cmd/nodereset.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"log"
-	"os"
-	"path/filepath"
-
 	"github.com/platform9/nodeadm/constants"
 	"github.com/platform9/nodeadm/utils"
 	"github.com/spf13/cobra"
+	"log"
+	"os"
+	"path/filepath"
 )
 
 // nodeCmd represents the cluster command
@@ -42,6 +41,10 @@ func cleanupKubelet() {
 	utils.StopAndDisableService("kubelet.service")
 	os.RemoveAll(filepath.Join(constants.SYSTEMD_DIR, "kubelet.service"))
 	os.RemoveAll(filepath.Join(constants.SYSTEMD_DIR, "kubelet.service.d"))
+	err := utils.ResetFailedService("kubelet")
+	if err != nil {
+		log.Fatalf("Failed to reset failed kubelet service %v\n", err)
+	}
 }
 
 func cleanupBinaries() {

--- a/utils/service.go
+++ b/utils/service.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 func reloadSystemd() error {
@@ -48,6 +49,36 @@ func serviceDisable(service string) error {
 	return exec.Command("systemctl", args...).Run()
 }
 
+func resetFailed(service string) error {
+	args := []string{"reset-failed", service}
+	if err := exec.Command("systemctl", args...).Run(); err != nil {
+		return fmt.Errorf("failed to reset failed service: %v", err)
+	}
+	return nil
+}
+
+func isFailed(service string) (bool, error) {
+	args := []string{"is-failed", service}
+	out, err := exec.Command("systemctl", args...).CombinedOutput()
+
+	if err != nil {
+		switch err.(type) {
+		// systemctl ran and exited
+		case *exec.ExitError:
+			return false, nil
+		// exec encountered a different error
+		default:
+			return false, err
+		}
+	}
+	// We could return true,nil here but let's check stdout just to make sure
+	if strings.TrimSpace(string(out)) == "failed" {
+		return true, nil
+	}
+	// We shouldn't hit this point but this is required.
+	return false, nil
+}
+
 // EnableAndStartService enables and starts the etcd service
 func EnableAndStartService(unitFile string) error {
 	err := serviceEnable(unitFile)
@@ -70,6 +101,20 @@ func StopAndDisableService(unitFile string) error {
 	err = serviceDisable(unitFile)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// ResetFailedService invokes reset-failed on a service if
+// the service satisfies the is-failed query, otherwise a noop
+func ResetFailedService(unitFile string) error {
+	// Check to see if the service actually failed
+	failed, err := isFailed(unitFile)
+	if err != nil {
+		return err
+	}
+	if failed {
+		return resetFailed(unitFile)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix 'Failed Unit' error after nodeadm reset

It turns out that the 1.10.x kubelet binaries exit with non-zero exit codes when terminated.
I’ve tested both 1.10.4 and 1.10.5 and both exhibit this behavior. On the other hand,
something changed in 1.11.0 which fixes this issue.
Terminating kubelet in 1.11.0 produces an exit code of 0.

I've searched through the 1.11 changelogs and I coudn’t find anything mentioning
about an exit code fix for kubelet (there was one for kubectl however).

This exit code issue causes an error to be displayed after login:

    $ ssh root@10.105.16.12
    Last login: Thu Jul 12 18:57:51 UTC 2018 from 10.32.32.139 on pts/0
    Container Linux by CoreOS stable (1745.3.1)
    Update Strategy: No Reboots
    Failed Units: 1
      kubelet.service

Invoking 'systemctl reset-failed kubelet'  fixes the issue.