### PR TITLE
Updated directory structure and have versioned names

### DIFF
--- a/cmd/nodereset.go
+++ b/cmd/nodereset.go
@@ -55,7 +55,6 @@ func cleanupBinaries() {
 	os.RemoveAll(filepath.Join(constants.BaseInstallDir, "kubeadm"))
 	os.RemoveAll(filepath.Join(constants.BaseInstallDir, "kubectl"))
 
-	os.RemoveAll(constants.KubeVersionInstallDir)
 	os.RemoveAll(constants.ConfInstallDir)
 	os.RemoveAll(constants.CNIBaseDir)
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -25,21 +25,17 @@ const (
 	KubeadmConfig        = "/tmp/kubeadm.yaml"
 	KubeDNSVersion       = "1.14.8"
 	KeepalivedImage      = "platform9/keepalived:v2.0.4"
-	CacheBaseDir         = "/var/cache/nodeadm/"
+	CacheDir             = "/var/cache/nodeadm/"
 	Execute              = 0744
 	Read                 = 0644
 	ServiceNodePortRange = "80-32767"
 )
 
-var KubeDirName = "kubernetes-" + KubernetesVersion
-var CNIDirName = "cni-" + CNIVersion
-var FlannelDirName = "flannel-" + FlannelVersion
-var NodeadmDirName = "noedadm-" + KubernetesVersion
-
-var KubeVersionInstallDir = filepath.Join(BaseInstallDir, KubeDirName)
-var CniVersionInstallDir = filepath.Join(CNIBaseDir, CNIDirName)
+var KubeDirName = filepath.Join("kubernetes", KubernetesVersion)
+var FlannelDirName = filepath.Join("flannel", FlannelVersion)
+var CNIDirName = filepath.Join("cni", CNIVersion)
+var CniVersionInstallDir = filepath.Join(CNIBaseDir, CNIVersion)
 var ConfInstallDir = filepath.Join(BaseInstallDir, ConfigDir)
-var CacheDir = filepath.Join(CacheBaseDir, KubernetesVersion)
 var ImagesCacheDir = filepath.Join(CacheDir, "images")
 
 const (

--- a/utils/install.go
+++ b/utils/install.go
@@ -92,14 +92,9 @@ func placeAndModifyNodeadmKubeletSystemdDropin(netConfig apis.Networking) {
 }
 
 func placeKubeComponents() {
-	err := os.MkdirAll(constants.KubeVersionInstallDir, constants.Execute)
-	if err != nil {
-		log.Fatalf("Failed to create dir %s with error %v\n", constants.KubeVersionInstallDir, err)
-	}
-	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubectl"), filepath.Join(constants.KubeVersionInstallDir, "kubectl"))
-	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubeadm"), filepath.Join(constants.KubeVersionInstallDir, "kubeadm"))
-	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubelet"), filepath.Join(constants.KubeVersionInstallDir, "kubelet"))
-	CreateSymLinks(constants.KubeVersionInstallDir, constants.BaseInstallDir, true)
+	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubectl"), filepath.Join(constants.BaseInstallDir, "kubectl"))
+	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubeadm"), filepath.Join(constants.BaseInstallDir, "kubeadm"))
+	deprecated.Run("", "cp", filepath.Join(constants.CacheDir, constants.KubeDirName, "kubelet"), filepath.Join(constants.BaseInstallDir, "kubelet"))
 }
 
 func placeCNIPlugin() {


### PR DESCRIPTION
Updated `/var/cache` to have a consistent format. 
Updated directory names to have versions, to allow multiple installations to coexist
Have `/opt/bin` to have actual binaries and not symlinks (as we now have versioned binaries in cache)

Also change the directory names for other binaries to follow the same pattern of
`/var/cache/<parent-tool>/<tool>/<tool-version>/<tool-binary>` (by parent tool we mean the one which uses the tool, e.g. ssh-provider is the parent tool for nodeadm, while nodeadm is the parent tool for kubernetes)

#### contents of `/var/cache`
```
coreos-puneet-199-10-105-16-14platform9 cache # find nodeadm/
nodeadm/
nodeadm/kubernetes
nodeadm/kubernetes/v1.10.4
nodeadm/kubernetes/v1.10.4/10-kubeadm.conf
nodeadm/kubernetes/v1.10.4/kubeadm
nodeadm/kubernetes/v1.10.4/kubelet.service
nodeadm/kubernetes/v1.10.4/kubectl
nodeadm/kubernetes/v1.10.4/kubelet
nodeadm/cni
nodeadm/cni/v0.6.0
nodeadm/cni/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
nodeadm/images
nodeadm/images/80cc5ea4b547abe174d7550b82825ace40769e977cde90495df3427b3a0f4e75.tar
nodeadm/images/c2ce1ffb51ed60c54057f53b8756231f5b4b792ce04113c6755339a1beb25943.tar
...
nodeadm/flannel
nodeadm/flannel/v0.10.0
nodeadm/flannel/v0.10.0/kube-flannel.yml

coreos-puneet-199-10-105-16-14platform9 cache # find etcdadm/
etcdadm/
etcdadm/etcd
etcdadm/etcd/v3.3.8
etcdadm/etcd/v3.3.8/etcd-v3.3.8-linux-amd64.tar.gz

coreos-puneet-199-10-105-16-14platform9 cache # find ssh-provider/
ssh-provider/
ssh-provider/nodeadm
ssh-provider/nodeadm/v.0.0.1-alpha
ssh-provider/nodeadm/v.0.0.1-alpha/nodeadm
ssh-provider/etcdadm
ssh-provider/etcdadm/v.0.0.1-alpha
ssh-provider/etcdadm/v.0.0.1-alpha/etcdadm
```
#### contents of `/opt/bin` 
```
coreos-puneet-199-10-105-16-14platform9 bin # ls
cctl  conf  etcd  etcdadm  etcdctl  exporter  kubeadm  kubectl  kubelet  nodeadm

```