### PR TITLE
Nodeadm init hangs and tries to get stable version from internet

### DIFF
--- a/apis/defaults.go
+++ b/apis/defaults.go
@@ -15,6 +15,8 @@ func SetInitDefaults(config *InitConfiguration) {
 	SetMasterConfigurationNetworkingDefaultsWithNetworking(config)
 	// Third use the remainder of MasterConfiguration defaults
 	kubeadmv1alpha1.SetDefaults_MasterConfiguration(&config.MasterConfiguration)
+	config.MasterConfiguration.Kind = "MasterConfiguration"
+	config.MasterConfiguration.APIVersion = "kubeadm.k8s.io/v1alpha1"
 	config.MasterConfiguration.KubernetesVersion = constants.KubernetesVersion
 	config.MasterConfiguration.NoTaintMaster = true
 	config.MasterConfiguration.APIServerExtraArgs = map[string]string{


### PR DESCRIPTION
We hit https://github.com/kubernetes/kubernetes/issues/54188 if Kind and APIVersion is not set in config.yaml. (These are set as omit if empty upstream)