### PR TITLE
QPS changes

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -52,13 +52,15 @@ var CNIPluginsFilename = fmt.Sprintf("cni-plugins-amd64-%s.tgz", CNIVersion)
 
 const (
 	// TODO(dlipovetsky) Move fields to configuration
-	KubeletFailSwapOn = false
-	KubeletMaxPods    = 500
+	KubeletFailSwapOn   = false
+	KubeletMaxPods      = 500
+	KubeletKubeAPIQPS   = 20
+	KubeletKubeAPIBurst = 40
 
 	NodeadmKubeletSystemdDropinFilename = "20-nodeadm.conf"
 	NodeadmKubeletSystemdDropinTemplate = `[Service]
 Environment="KUBELET_DNS_ARGS=--cluster-dns={{ .ClusterDNS }} --cluster-domain={{ .ClusterDomain }}"
-Environment="KUBELET_EXTRA_ARGS=--max-pods={{ .MaxPods }} --fail-swap-on={{ .FailSwapOn }} --hostname-override={{ .HostnameOverride }}"
+Environment="KUBELET_EXTRA_ARGS=--max-pods={{ .MaxPods }} --fail-swap-on={{ .FailSwapOn }} --hostname-override={{ .HostnameOverride }} --kube-api-qps={{ .KubeAPIQPS }} --kube-api-burst={{ .KubeAPIBurst }}"
 `
 )
 

--- a/utils/install.go
+++ b/utils/install.go
@@ -80,12 +80,16 @@ func placeAndModifyNodeadmKubeletSystemdDropin(netConfig apis.Networking) {
 		ClusterDNS       string
 		ClusterDomain    string
 		HostnameOverride string
+		KubeAPIQPS       int
+		KubeAPIBurst     int
 	}{
 		FailSwapOn:       constants.KubeletFailSwapOn,
 		MaxPods:          constants.KubeletMaxPods,
 		ClusterDNS:       dnsIP.String(),
 		ClusterDomain:    netConfig.DNSDomain,
 		HostnameOverride: hostnameOverride,
+		KubeAPIQPS:       constants.KubeletKubeAPIQPS,
+		KubeAPIBurst:     constants.KubeletKubeAPIBurst,
 	}
 
 	writeTemplateIntoFile(constants.NodeadmKubeletSystemdDropinTemplate, "nodeadm-kubelet-systemd-dropin", confFile, data)


### PR DESCRIPTION
Increase default kube-api-qps to 20 and also
bump kube-api-burst to 40

## kubelet parameters
```
/opt/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true --network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --cluster-dns=10.1.0.10 --cluster-domain=cluster.local --authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt --cgroup-driver=cgroupfs --cadvisor-port=0 --rotate-certificates=true --max-pods=500 --fail-swap-on=false --hostname-override=10.105.16.53 --kube-api-qps=20 --kube-api-burst=40
```
## Ran 1000 nginx pods on 5 node cluster
```
coreos-puneet-370-10-105-16-53platform9 ~ # kubectl get pods --all-namespaces | grep nginx | grep -i Running | wc
   1000    6000   88000
```