### PR TITLE
Refactor code s.t. workarounds are in respective packages

### DIFF
--- a/apis/defaults.go
+++ b/apis/defaults.go
@@ -1,16 +1,14 @@
-package defaults
+package apis
 
 import (
 	"fmt"
 
-	"github.com/platform9/nodeadm/apis"
 	"github.com/platform9/nodeadm/constants"
-	"github.com/platform9/nodeadm/workarounds"
 	kubeadmv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 )
 
 // SetInitDefaults sets defaults on the configuration used by init
-func SetInitDefaults(config *apis.InitConfiguration) {
+func SetInitDefaults(config *InitConfiguration) {
 	// First set Networking defaults
 	SetNetworkingDefaults(&config.Networking)
 	// Second set MasterConfiguration.Networking defaults
@@ -27,7 +25,7 @@ func SetInitDefaults(config *apis.InitConfiguration) {
 }
 
 // SetInitDynamicDefaults sets defaults derived at runtime
-func SetInitDynamicDefaults(config *apis.InitConfiguration) error {
+func SetInitDynamicDefaults(config *InitConfiguration) error {
 	nodeName, err := constants.GetHostnameOverride()
 	if err != nil {
 		return fmt.Errorf("unable to dervice hostname override: %v", err)
@@ -37,12 +35,12 @@ func SetInitDynamicDefaults(config *apis.InitConfiguration) error {
 }
 
 // SetJoinDefaults sets defaults on the configuration used by join
-func SetJoinDefaults(config *apis.JoinConfiguration) {
+func SetJoinDefaults(config *JoinConfiguration) {
 	SetNetworkingDefaults(&config.Networking)
 }
 
 // SetNetworkingDefaults sets defaults for the network configuration
-func SetNetworkingDefaults(netConfig *apis.Networking) {
+func SetNetworkingDefaults(netConfig *Networking) {
 	if netConfig.ServiceSubnet == "" {
 		netConfig.ServiceSubnet = constants.DefaultServiceSubnet
 	}
@@ -53,7 +51,7 @@ func SetNetworkingDefaults(netConfig *apis.Networking) {
 
 // SetMasterConfigurationNetworkingDefaultsWithNetworking sets defaults with
 // values from the top-level network configuration
-func SetMasterConfigurationNetworkingDefaultsWithNetworking(config *apis.InitConfiguration) {
+func SetMasterConfigurationNetworkingDefaultsWithNetworking(config *InitConfiguration) {
 	if config.MasterConfiguration.Networking.ServiceSubnet == "" {
 		config.MasterConfiguration.Networking.ServiceSubnet = config.Networking.ServiceSubnet
 	}
@@ -61,7 +59,7 @@ func SetMasterConfigurationNetworkingDefaultsWithNetworking(config *apis.InitCon
 	if config.MasterConfiguration.Networking.PodSubnet == "" {
 		// Set controller manager extra args directly because of the issue
 		// https://github.com/kubernetes/kubeadm/issues/724
-		workarounds.SetControllerManagerExtraArgs(config)
+		setControllerManagerExtraArgs(config)
 	}
 	if config.MasterConfiguration.Networking.DNSDomain == "" {
 		config.MasterConfiguration.Networking.DNSDomain = config.Networking.DNSDomain

--- a/apis/validation.go
+++ b/apis/validation.go
@@ -1,14 +1,13 @@
-package defaults
+package apis
 
 import (
 	"fmt"
 
-	"github.com/platform9/nodeadm/apis"
 	"github.com/platform9/nodeadm/constants"
 )
 
 // ValidateInit validates the configuration used by the init verb
-func ValidateInit(config *apis.InitConfiguration) []error {
+func ValidateInit(config *InitConfiguration) []error {
 	var errorList []error
 	if config.MasterConfiguration.Networking.ServiceSubnet != config.Networking.ServiceSubnet {
 		errorList = append(errorList, fmt.Errorf("configuration conflict: Networking.ServiceSubnet=%q, MasterConfiguration.Networking.ServiceSubnet=%q. Values should be identical, or MasterConfiguration.Networking.ServiceSubnet omitted",

--- a/apis/workaround_kubeadm_issue_724.go
+++ b/apis/workaround_kubeadm_issue_724.go
@@ -1,12 +1,11 @@
-package workarounds
+package apis
 
 import (
-	"github.com/platform9/nodeadm/apis"
 	"github.com/platform9/nodeadm/constants"
 )
 
 // SetControllerManagerExtraArgs sets controller manager extra args for a given pod network subnet
-func SetControllerManagerExtraArgs(config *apis.InitConfiguration) {
+func setControllerManagerExtraArgs(config *InitConfiguration) {
 	if _, ok := config.MasterConfiguration.ControllerManagerExtraArgs[constants.ControllerManagerAllocateNodeCIDRsKey]; !ok {
 		config.MasterConfiguration.ControllerManagerExtraArgs[constants.ControllerManagerAllocateNodeCIDRsKey] = constants.ControllerManagerAllocateNodeCIDRs
 	}

--- a/cmd/nodeinit.go
+++ b/cmd/nodeinit.go
@@ -12,11 +12,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/platform9/nodeadm/workarounds"
-
 	"github.com/platform9/nodeadm/apis"
 	"github.com/platform9/nodeadm/constants"
-	"github.com/platform9/nodeadm/defaults"
 	"github.com/platform9/nodeadm/utils"
 	"github.com/spf13/cobra"
 )
@@ -35,11 +32,11 @@ var nodeCmdInit = &cobra.Command{
 				log.Fatalf("Failed to read configuration from file %q: %v", configPath, err)
 			}
 		}
-		defaults.SetInitDefaults(config)
-		if err := defaults.SetInitDynamicDefaults(config); err != nil {
+		apis.SetInitDefaults(config)
+		if err := apis.SetInitDynamicDefaults(config); err != nil {
 			log.Fatalf("Failed to set dynamic defaults: %v", err)
 		}
-		if errors := defaults.ValidateInit(config); len(errors) > 0 {
+		if errors := apis.ValidateInit(config); len(errors) > 0 {
 			log.Error("Failed to validate configuration:")
 			for i, err := range errors {
 				log.Errorf("%v: %v", i, err)
@@ -61,7 +58,7 @@ var nodeCmdInit = &cobra.Command{
 		kubeadmInit(constants.KubeadmConfig)
 
 		log.Infoln("Applying workaround for https://github.com/kubernetes/kubeadm/issues/857")
-		if err := workarounds.EnsureKubeProxyRespectsHostoverride(); err != nil {
+		if err := ensureKubeProxyRespectsHostoverride(); err != nil {
 			log.Fatalf("Failed to apply workaround: %v", err)
 		}
 

--- a/cmd/nodejoin.go
+++ b/cmd/nodejoin.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/platform9/nodeadm/apis"
 	"github.com/platform9/nodeadm/constants"
-	"github.com/platform9/nodeadm/defaults"
 	"github.com/platform9/nodeadm/utils"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +27,7 @@ var nodeCmdJoin = &cobra.Command{
 				log.Fatalf("Failed to read configuration from file %q: %v", configPath, err)
 			}
 		}
-		defaults.SetJoinDefaults(config)
+		apis.SetJoinDefaults(config)
 		utils.InstallNodeComponents(config)
 		kubeadmJoin(cmd.Flag("token").Value.String(),
 			cmd.Flag("master").Value.String(),

--- a/cmd/workaround_kubeadm_issue_857.go
+++ b/cmd/workaround_kubeadm_issue_857.go
@@ -1,4 +1,4 @@
-package workarounds
+package cmd
 
 import (
 	"bytes"
@@ -83,7 +83,7 @@ const (
 // EnsureKubeProxyRespectsHostoverride patches the kube-proxy daemonset so that
 // kube-proxy respects the hostnameOverride setting. The function is idempotent.
 // See: https://github.com/kubernetes/kubeadm/issues/857
-func EnsureKubeProxyRespectsHostoverride() error {
+func ensureKubeProxyRespectsHostoverride() error {
 	log.Infoln("[workarounds] Checking whether kube-proxy daemonset is patched")
 	patched, err := isPatchedKubeProxyDaemonSet()
 	if err != nil {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -15,7 +15,6 @@ const (
 	CNIConfigDir                          = "/etc/cni"
 	CNIStateDir                           = "/var/lib/cni"
 	SystemdDir                            = "/etc/systemd/system"
-	ConfigDir                             = "conf"
 	FlannelVersion                        = "v0.10.0"
 	DefaultPodNetwork                     = "10.244.0.0/16"
 	DefaultDNSIP                          = "10.96.0.10"


### PR DESCRIPTION
Having a separate package for workarounds can easily cause circular dependencies where:
Workaround depends on API
A package depending on workarounds and APIs will cause a cycle.

Instead keep workarounds in respective packages where they are needed