### PR TITLE
Upgrade kubernetes to 1.10.11 for CVE-2018-1002105

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	KubernetesVersion                     = "v1.10.4"
+	KubernetesVersion                     = "v1.10.11"
 	CNIVersion                            = "v0.6.0"
 	BaseInstallDir                        = "/opt/bin"
 	CNIBaseDir                            = "/opt/cni/bin"


### PR DESCRIPTION
Tried running gravitational's utility https://github.com/gravitational/cve-2018-1002105 

```
isv-puneet-872-10-105-16-112platform9 bin # docker run -it --rm -v /etc/kubernetes/admin.conf:/kubeconfig: quay.io/gravitational/cve-2018-1002105:latest
Please Note:
  This test currently relies on the behaviour of apiserver/kubelet to check for the issue.
  If you're connecting through a layer-7 load balancer, you may receive false positives in the test
Attempting to locate and load kubeconfig file
Loading: /kubeconfig
Testing for unauthenticated access...
> API allows unauthenticated access
Testing for privilege escalation...
isv-puneet-872-10-105-16-112platform9 bin #
```

## Observations
### unauthenticated access
```
Testing for unauthenticated access...
> API allows unauthenticated access
```
This is expected, as anonymous anonymous access is enabled by default if an authorization mode other than AlwaysAllow is used. https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
Authorization Mode used for nodeadm is `--authorization-mode=Node,RBAC` 

### privilege escalation
```
> API allows unauthenticated access
Testing for privilege escalation...
isv-puneet-872-10-105-16-112platform9 bin #
```
Above shows that cluster is no longer vulnerable to CVE-2018-1002105. 

Tried running the same test utility on a 1.10.4 cluster 
```
./kubectl get nodes
NAME           STATUS    ROLES     AGE       VERSION
10.105.16.44   Ready     <none>    5d        v1.10.4
10.105.16.57   Ready     master    5d        v1.10.4
10.105.16.59   Ready     master    5d        v1.10.4
10.105.16.79   Ready     <none>    5d        v1.10.4
10.105.16.82   Ready     master    5d        v1.10.4
```
It clearly says that the cluster is vulnerable **API is vulnerable to CVE-2018-1002105**
```
Loading: /kubeconfig
Testing for unauthenticated access...
> API allows unauthenticated access
Testing for privilege escalation...
> API is vulnerable to CVE-2018-1002105
```
