### PR TITLE
Clean up keepalived if it fails to start correctly

### DIFF
--- a/utils/install.go
+++ b/utils/install.go
@@ -283,7 +283,7 @@ ExecStart=/usr/bin/docker run --cap-add=NET_ADMIN \
 ExecStartPre=-/usr/bin/docker kill vip
 ExecStartPre=-/usr/bin/docker rm vip
 ExecStop=/usr/bin/docker stop vip
-ExecStop=/usr/bin/docker rm vip
+ExecStopPost=/usr/bin/docker rm vip
 Restart=on-failure
 MemoryLow=10M
 [Install]


### PR DESCRIPTION
It was determined that it was not necessary to have the keeplived container for debugging post-mortem if the logs are available via journald on the host. 

[It is recommended to use this setting for clean-up operations that shall be executed even when the service failed to start up correctly.](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStopPost=)